### PR TITLE
Add timeout for connection

### DIFF
--- a/src/main/java/org/update4j/Configuration.java
+++ b/src/main/java/org/update4j/Configuration.java
@@ -995,6 +995,8 @@ public class Configuration {
 
 					// Some downloads may fail with HTTP/403, this may solve it
 					connection.addRequestProperty("User-Agent", "Mozilla/5.0");
+					// Set a connection timeout of 10 seconds
+					connection.setConnectTimeout(10 * 1000);
 					try (InputStream in = connection.getInputStream();
 									OutputStream out = Files.newOutputStream(output)) {
 


### PR DESCRIPTION
This PR tries to resolve issue #30 by setting a timeout of 10 seconds on the URLConnection. If the timeout occurs, a SocketTimeoutException is raised. This will be caught by the routine of cleanup like other errors. 