### PR TITLE
String.toLowerCase() is locale dependent

### DIFF
--- a/src/main/java/org/update4j/OS.java
+++ b/src/main/java/org/update4j/OS.java
@@ -15,13 +15,15 @@
  */
 package org.update4j;
 
+import java.util.Locale;
+
 public enum OS {
 	WINDOWS("win"), MAC("mac"), LINUX("linux"), OTHER("other");
 
 	public static final OS CURRENT;
 
 	static {
-		String os = System.getProperty("os.name", "generic").toLowerCase();
+		String os = System.getProperty("os.name", "generic").toLowerCase(Locale.ROOT);
 
 		if ((os.contains("mac")) || (os.contains("darwin")))
 			CURRENT = MAC;


### PR DESCRIPTION
Hi, just found your project and saw this tiny bug. String.toLowercase() is locale dependent, and `"WINDOWS".toLowercase().equals("windows")` will not always be true. Check out Javadoc for String.toLowercase(Locale) for more info (i.e. there's a lowercase "i" without dot on it in turkish).