### PR TITLE
Fix mistaken blocking call on launchFirst()

### DIFF
--- a/src/main/java/org/update4j/service/DefaultBootstrap.java
+++ b/src/main/java/org/update4j/service/DefaultBootstrap.java
@@ -252,7 +252,7 @@ public class DefaultBootstrap implements Delegate {
         if (!localNotReady) {
             Configuration finalConfig = localConfig;
             Thread localApp = new Thread(() -> finalConfig.launch());
-            localApp.run();
+            localApp.start();
         }
 
         Configuration remoteConfig = null;


### PR DESCRIPTION
I am new to Update4J and maybe I am totally wrong, but I tried to use the DefaultBoostrap with "--launchFirst" and it did not update at all.

`java -cp update4j-1.4.5.jar org.update4j.Bootstrap --local update-config.xml --remote http://<server:port>/application/config.xml --syncLocal --launchFirst --singleInstance`

Without "--launchFirst" it works fine.

I think I identified the issue with a blocking call to the application.

This should have never worked in the first place. Did I miss something?