### PR TITLE
Added a github action that run mvn verify on each push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+---
+name: Java CI
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, macOS-latest, windows-latest]
+        java: [11, 15, 16-ea]
+      fail-fast: false
+      max-parallel: 4
+    name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Verify with Maven
+        run: mvn clean verify -B --file pom.xml
+...


### PR DESCRIPTION
On each push mvn clean verify will be executed on Ubuntu 18.04, latest MacOS and latest Windows using JDK 11, 15 and 16-ea. I thought you might want to give it a try because it doesn't hurt :)