### PR TITLE
Add arch attribute to FileMetadata, #180

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.update4j</groupId>
 	<artifactId>update4j</artifactId>
-	<version>1.5.9</version>
+	<version>1.5.10-SNAPSHOT</version>
 	<name>update4j</name>
 	<description>Update and launch Java 9+ Applications</description>
 	<url>https://github.com/update4j/update4j</url>

--- a/src/main/java/org/update4j/ConfigImpl.java
+++ b/src/main/java/org/update4j/ConfigImpl.java
@@ -101,7 +101,8 @@ class ConfigImpl {
 
             List<FileMetadata> osFiles = config.getFiles()
                             .stream()
-                            .filter(file -> file.getOs() == null || file.getOs() == OS.CURRENT)
+                            .filter(file -> file.getOs() == null || (file.getOs() == OS.CURRENT && 
+                            (file.getArch() == null || System.getProperty("os.arch").equals(file.getArch()))))
                             .collect(Collectors.toList());
 
             long updateJobSize = osFiles.stream().mapToLong(FileMetadata::getSize).sum();
@@ -271,7 +272,8 @@ class ConfigImpl {
 
             List<FileMetadata> osFiles = config.getFiles()
                             .stream()
-                            .filter(file -> file.getOs() == null || file.getOs() == OS.CURRENT)
+                            .filter(file -> file.getOs() == null || (file.getOs() == OS.CURRENT && 
+                            (file.getArch() == null || System.getProperty("os.arch").equals(file.getArch()))))
                             .collect(Collectors.toList());
 
             long updateJobSize = osFiles.stream().mapToLong(FileMetadata::getSize).sum();
@@ -546,7 +548,8 @@ class ConfigImpl {
     static void doLaunch(Configuration config, Injectable injectable, Launcher launcher) {
         List<FileMetadata> modules = config.getFiles()
                         .stream()
-                        .filter(file -> file.getOs() == null || file.getOs() == OS.CURRENT)
+                        .filter(file -> file.getOs() == null || (file.getOs() == OS.CURRENT && 
+                        (file.getArch() == null || System.getProperty("os.arch").equals(file.getArch()))))
                         .filter(FileMetadata::isModulepath)
                         .collect(Collectors.toList());
 
@@ -554,7 +557,8 @@ class ConfigImpl {
 
         List<URL> classpaths = config.getFiles()
                         .stream()
-                        .filter(file -> file.getOs() == null || file.getOs() == OS.CURRENT)
+                        .filter(file -> file.getOs() == null || (file.getOs() == OS.CURRENT && 
+                        (file.getArch() == null || System.getProperty("os.arch").equals(file.getArch()))))
                         .filter(FileMetadata::isClasspath)
                         .map(FileMetadata::getNormalizedPath)
                         .map(path -> {

--- a/src/main/java/org/update4j/Configuration.java
+++ b/src/main/java/org/update4j/Configuration.java
@@ -1847,6 +1847,8 @@ public class Configuration {
 
             if (fm.os != null)
                 fileBuilder.os(fm.os);
+            if (fm.arch != null)
+                fileBuilder.arch(fm.arch);
 
             // defaults to false
             fileBuilder.modulepath(fm.modulepath != null && fm.modulepath);

--- a/src/main/java/org/update4j/mapper/ConfigMapper.java
+++ b/src/main/java/org/update4j/mapper/ConfigMapper.java
@@ -20,7 +20,6 @@ import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Signature;

--- a/src/main/java/org/update4j/mapper/FileMapper.java
+++ b/src/main/java/org/update4j/mapper/FileMapper.java
@@ -33,6 +33,7 @@ public class FileMapper extends XmlMapper {
     public String checksum;
     public Long size;
     public OS os;
+    public String arch;
     public Boolean classpath;
     public Boolean modulepath;
     public String comment;
@@ -60,6 +61,7 @@ public class FileMapper extends XmlMapper {
         checksum = copy.checksum;
         size = copy.size;
         os = copy.os;
+        arch = copy.arch;
         classpath = copy.classpath;
         modulepath = copy.modulepath;
         comment = copy.comment;
@@ -89,6 +91,8 @@ public class FileMapper extends XmlMapper {
         if (os != null) {
             this.os = OS.fromShortName(os);
         }
+
+        arch = getAttributeValue(node, "arch");
 
         String classpath = getAttributeValue(node, "classpath");
         if (classpath != null) {
@@ -179,6 +183,9 @@ public class FileMapper extends XmlMapper {
         }
         if (os != null) {
             builder.append(" os=\"" + os.getShortName() + "\"");
+        }
+        if(arch != null) {
+            builder.append(" arch=\"" + arch + "\"");
         }
         if (classpath != null && classpath) {
             builder.append(" classpath=\"true\"");

--- a/src/main/java/org/update4j/util/FileUtils.java
+++ b/src/main/java/org/update4j/util/FileUtils.java
@@ -49,7 +49,7 @@ import org.update4j.OS;
 
 public class FileUtils {
 
-    public static final Pattern OS_PATTERN = Pattern.compile(".+-(linux|win|mac)\\.[^.]+");
+    public static final Pattern OS_PATTERN = Pattern.compile(".+-(linux|win|mac)(?:-(.+))?\\.[^.]+$");
 
     private FileUtils() {
     }
@@ -182,14 +182,17 @@ public class FileUtils {
         return base.resolve(child.toString().replaceFirst("^\\\\|/", ""));
     }
 
-    public static OS fromFilename(String filename) {
-        Matcher osMatcher = OS_PATTERN.matcher(filename);
+    public static FilenameMatch fromFilename(String filename) {
+        Matcher filenameMatcher = OS_PATTERN.matcher(filename);
 
-        if (osMatcher.matches()) {
-            return OS.fromShortName(osMatcher.group(1));
+        OS os = null;
+        String arch = null;
+        if (filenameMatcher.matches()) {
+            os = OS.fromShortName(filenameMatcher.group(1));
+            arch = filenameMatcher.group(2);
         }
 
-        return null;
+        return new FilenameMatch(os, arch);
     }
 
     public static boolean isEmptyDirectory(Path path) throws IOException {

--- a/src/main/java/org/update4j/util/FilenameMatch.java
+++ b/src/main/java/org/update4j/util/FilenameMatch.java
@@ -1,0 +1,22 @@
+package org.update4j.util;
+
+import org.update4j.OS;
+
+public class FilenameMatch {
+	
+    private OS os;
+    private String arch;
+    
+    public FilenameMatch(OS os, String arch) {
+        this.os = os;
+        this.arch = arch;
+    }
+
+    public OS getOs() {
+        return os;
+    }
+
+    public String getArch() {
+        return arch;
+    }
+}


### PR DESCRIPTION
Add support to download file by architecture per #180 
To avoid file conflicts, you can only use the `arch` property together with the `os` property.

This branch adds support for this feature but is completely untested and doesn't properly check for invalid configurations.
An especially unchecked case is with the following snippet of code, where we need to add checks for arch.

https://github.com/update4j/update4j/blob/91d9288823db690e08d0fd2a5888534c22737075/src/main/java/org/update4j/Configuration.java#L1871-L1882